### PR TITLE
Fix `Time.every` not working in conditional subscription

### DIFF
--- a/src/Time.ts
+++ b/src/Time.ts
@@ -45,6 +45,7 @@ function cleanupIntervalForDelay(delay: number) {
   const handle = everyIntervals[delay];
   if (handle) {
     clearInterval(handle);
+    everyIntervals[delay] = undefined;
   }
 }
 


### PR DESCRIPTION
Problem: Originally reported in https://github.com/vankeisb/react-tea-cup/issues/127,

Time.every only work once in conditional subscription. 
After a condition that would trigger `Time.every` again, it will not trigger.

Solution:
- Set `everyIntervals[delay]` to undefined after doing `clearInterval`